### PR TITLE
Implement POST /api/:username/lights for adding new light

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -226,17 +226,19 @@ app.get('/api/:username/lights/new', whitelist, function(req, res) {
 // accept a new light object and add it to lights list
 // since this isn't a real feature of the Hue bridge API, didn't modify the return value
 app.post('/api/:username/lights', whitelist, function(req, res) {
-    //figure out next index
-    var numKeys = Object.keys(app.get('state').lights).length;
-    //Clone one of the existing objects as a placeholder at the new index
-    app.get('state').lights[numKeys + 1] = JSON.parse(JSON.stringify(app.get('state').lights[1]));
-    var newLight = app.get('state').lights[numKeys + 1];
-    //update name
-    if(req.body.name != null && req.body.name != undefined){
-    	newLight.name = req.body.name;
+    if(req.body && req.body.length > 0){
+        //figure out next index
+        var numKeys = Object.keys(app.get('state').lights).length;
+        //Clone one of the existing objects as a placeholder at the new index
+        app.get('state').lights[numKeys + 1] = JSON.parse(JSON.stringify(app.get('state').lights[1]));
+        var newLight = app.get('state').lights[numKeys + 1];
+        //update name
+        if(req.body.name != null && req.body.name != undefined){
+        	newLight.name = req.body.name;
+        }
+        //update state
+        updateProperties(newLight.state,req.body.state,null);
     }
-    //update state
-    updateProperties(newLight.state,req.body.state,null);
     res.send(200, JSON.stringify([{"success": {"/lights": "Searching for new devices"}}]));
 });
 


### PR DESCRIPTION
Currently there is no way to dynamically add new lights to the set of existing lights, so I modified the POST method on the /lights endpoint to accept a new light object and add it to the list, while not changing the response signature at all.
