### PR TITLE
adding ability to configure hostname/port

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ As I started development of hueJS before getting my Hue starter kit, i needed to
 
 Using npm:
 
-```
+```sh
 sudo npm install -g hue-simulator
 ```
 
@@ -15,10 +15,20 @@ It should be installed [globally](http://blog.nodejitsu.com/npm-cheatsheet#Under
 ## Run
 
 Start the simulator via command line:
-```
+
+```sh
+# start the simulator on localhost:80
 sudo hue-simulator
+
+# start the simulator on localhost:8080 #
+hue-simulator --port=8080
+
+# start the simulator on 127.0.3.1:80 #
+sudo ifconfig lo0 alias 127.0.3.1
+sudo hue-simulator --hostname=127.0.3.1
 ```
-Sudo is necessary because we want to listen on port 80.
+
+Sudo is necessary when we want to listen on port 80, a so called low-port that are restricted to the unix root user.
 
 ## Debugger
 

--- a/bin/hue-simulator
+++ b/bin/hue-simulator
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 
+var parseArgs = require('minimist')
+var options = parseArgs(process.argv.slice(2), {
+    "default": {
+        port: 80,
+        hostname: undefined
+    }
+});
+
 var bridge = require("../bridge.js");
 
-bridge.listen(80);
+bridge.listen(options.port, options.hostname);
 
-console.log("hue simulator listening on port 80");
+console.log("hue simulator listening on port " + options.port + ' ' + (!options.hostname ? 'on all interfaces' : ('on hostname ' + options.hostname)));

--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-    "name": "hue-simulator",
-    "description": "Simulate a philips hue bridge light system",
-    "keywords": [
-        "hue",
-        "bridge",
-        "simulator",
-        "philips"
-    ],
-    "license": "MIT",
-    "author": "Sven Riecker <sven@nooblucker.de>",
-    "version": "0.0.8",
-    "dependencies": {
-        "express": "3.x"
-    },
-    "engines": {
-        "node": ">=0.8.x",
-        "npm": "1.2.x"
-    },
-    "readmeFilename": "README.md",
-    "main": "bridge.js",
-    "scripts": {
-        "start": "node ./bin/hue-simulator",
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/nooblucker/hueSimulator"
-    },
-    "bugs": "https://github.com/nooblucker/hueSimulator/issues",
-    "preferGlobal": "true",
-    "bin": {
-        "hue-simulator": "./bin/hue-simulator"
-    }
+  "name": "hue-simulator",
+  "description": "Simulate a philips hue bridge light system",
+  "keywords": [
+    "hue",
+    "bridge",
+    "simulator",
+    "philips"
+  ],
+  "license": "MIT",
+  "author": "Sven Riecker <sven@nooblucker.de>",
+  "version": "0.0.8",
+  "dependencies": {
+    "express": "3.x",
+    "minimist": "0.0.8"
+  },
+  "engines": {
+    "node": ">=0.8.x",
+    "npm": "1.2.x"
+  },
+  "readmeFilename": "README.md",
+  "main": "bridge.js",
+  "scripts": {
+    "start": "node ./bin/hue-simulator",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nooblucker/hueSimulator"
+  },
+  "bugs": "https://github.com/nooblucker/hueSimulator/issues",
+  "preferGlobal": "true",
+  "bin": {
+    "hue-simulator": "./bin/hue-simulator"
+  }
 }


### PR DESCRIPTION
when starting the simulator from CLI using `hue-simulator --port=8080 --hostname=127.0.3.1`

(reformatting of `package.json` done by npm)
