### PR TITLE
Fix request payload encoding json

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -40,7 +40,16 @@ var whitelist = function(req, res, next) {
 
 app.use(express.logger());
 app.use(express.static(__dirname + '/public_html'));
-app.use(express.bodyParser());
+app.use(function(request, response, next) {
+    // http://developers.meethue.com/7_messagestructureresponse.html says the request body MUST be JSON,
+    // but the SDK doesn't necessarily send the proper headers
+    if (request.method === 'POST' || request.method === 'PUT') {
+        request.headers['content-type'] = 'application/json; charset=UTF-8';
+    }
+    
+    next();
+});
+app.use(express.json());
 app.use(allowCrossDomain);
 app.use(sendJSON);
 

--- a/public_html/js/main.js
+++ b/public_html/js/main.js
@@ -34,7 +34,8 @@ $(function() {
         try {
             if (body !== "") {
                 data = JSON.parse(body);
-                body = "<pre>"+JSON.stringify(data, null, 2)+"</pre>";
+                data = JSON.stringify(data, null, 2);
+                body = "<pre>" + data + "</pre>";
             }
         } catch (e) {
             alert('malformed json: ' + e);
@@ -47,6 +48,8 @@ $(function() {
             url: url,
             method: method,
             data: data,
+            contentType: 'application/json; charset=UTF-8',
+            accepts: 'application/json; charset=utf-8',
             dataType: "json"
         });
 


### PR DESCRIPTION
Fixing transfer encoding of POST/PUT requests (to JSON).

The WebUI accidentally sent `x-www-url-encoded`, but the [Hue only accepts `application/json`](http://developers.meethue.com/7_messagestructureresponse.html). This would have been a non-issue had the Hue SDK sent proper Content-Type request headers in the first place.
